### PR TITLE
UseArrowsInTerm option implementation

### DIFF
--- a/autoload/ctrlspace/context.vim
+++ b/autoload/ctrlspace/context.vim
@@ -54,6 +54,7 @@ let s:configuration = {
 			\ "Help":                     {},
 			\ "GlobCommand":              "",
 			\ "UseTabline":               1,
+			\ "UseArrowsInTerm":          0,
 			\ "UseMouseAndArrowsInTerm":  0,
 			\ "StatuslineFunction":       "ctrlspace#api#Statusline()",
 			\ "SaveWorkspaceOnExit":      0,

--- a/autoload/ctrlspace/keys/common.vim
+++ b/autoload/ctrlspace/keys/common.vim
@@ -134,19 +134,19 @@ function! ctrlspace#keys#common#LeftMouse2(k)
 endfunction
 
 function! ctrlspace#keys#common#DownArrow(k)
-	if s:config.UseMouseAndArrowsInTerm || has("gui_running")
+	if s:config.UseArrowsInTerm || s:config.UseMouseAndArrowsInTerm || has("gui_running")
 		call ctrlspace#window#MoveSelectionBar("down")
 	endif
 endfunction
 
 function! ctrlspace#keys#common#UpArrow(k)
-	if s:config.UseMouseAndArrowsInTerm || has("gui_running")
+	if s:config.UseArrowsInTerm || s:config.UseMouseAndArrowsInTerm || has("gui_running")
 		call ctrlspace#window#MoveSelectionBar("up")
 	endif
 endfunction
 
 function! ctrlspace#keys#common#Home(k)
-	if s:config.UseMouseAndArrowsInTerm || has("gui_running")
+	if s:config.UseArrowsInTerm || s:config.UseMouseAndArrowsInTerm || has("gui_running")
 		call ctrlspace#window#MoveSelectionBar(1)
 	endif
 endfunction
@@ -156,7 +156,7 @@ function! ctrlspace#keys#common#Top(k)
 endfunction
 
 function! ctrlspace#keys#common#End(k)
-	if s:config.UseMouseAndArrowsInTerm || has("gui_running")
+	if s:config.UseArrowsInTerm || s:config.UseMouseAndArrowsInTerm || has("gui_running")
 		call ctrlspace#window#MoveSelectionBar(line("$"))
 	endif
 endfunction
@@ -166,7 +166,7 @@ function! ctrlspace#keys#common#Bottom(k)
 endfunction
 
 function! ctrlspace#keys#common#PageDown(k)
-	if s:config.UseMouseAndArrowsInTerm || has("gui_running")
+	if s:config.UseArrowsInTerm || s:config.UseMouseAndArrowsInTerm || has("gui_running")
 		call ctrlspace#window#MoveSelectionBar("pgdown")
 	endif
 endfunction
@@ -176,7 +176,7 @@ function! ctrlspace#keys#common#ScrollDown(k)
 endfunction
 
 function! ctrlspace#keys#common#PageUp(k)
-	if s:config.UseMouseAndArrowsInTerm || has("gui_running")
+	if s:config.UseArrowsInTerm || s:config.UseMouseAndArrowsInTerm || has("gui_running")
 		call ctrlspace#window#MoveSelectionBar("pgup")
 	endif
 endfunction

--- a/autoload/ctrlspace/keys/help.vim
+++ b/autoload/ctrlspace/keys/help.vim
@@ -69,19 +69,19 @@ function! ctrlspace#keys#help#LeftMouse2(k)
 endfunction
 
 function! ctrlspace#keys#help#DownArrow(k)
-	if s:config.UseMouseAndArrowsInTerm || has("gui_running")
+	if s:config.UseArrowsInTerm || s:config.UseMouseAndArrowsInTerm || has("gui_running")
 		call ctrlspace#window#MoveCursor("down")
 	endif
 endfunction
 
 function! ctrlspace#keys#help#UpArrow(k)
-	if s:config.UseMouseAndArrowsInTerm || has("gui_running")
+	if s:config.UseArrowsInTerm || s:config.UseMouseAndArrowsInTerm || has("gui_running")
 		call ctrlspace#window#MoveCursor("up")
 	endif
 endfunction
 
 function! ctrlspace#keys#help#Home(k)
-	if s:config.UseMouseAndArrowsInTerm || has("gui_running")
+	if s:config.UseArrowsInTerm || s:config.UseMouseAndArrowsInTerm || has("gui_running")
 		call ctrlspace#window#MoveCursor(1)
 	endif
 endfunction
@@ -91,7 +91,7 @@ function! ctrlspace#keys#help#Top(k)
 endfunction
 
 function! ctrlspace#keys#help#End(k)
-	if s:config.UseMouseAndArrowsInTerm || has("gui_running")
+	if s:config.UseArrowsInTerm || s:config.UseMouseAndArrowsInTerm || has("gui_running")
 		call ctrlspace#window#MoveCursor(line("$"))
 	endif
 endfunction
@@ -101,7 +101,7 @@ function! ctrlspace#keys#help#Bottom(k)
 endfunction
 
 function! ctrlspace#keys#help#PageDown(k)
-	if s:config.UseMouseAndArrowsInTerm || has("gui_running")
+	if s:config.UseArrowsInTerm || s:config.UseMouseAndArrowsInTerm || has("gui_running")
 		call ctrlspace#window#MoveCursor("pgdown")
 	endif
 endfunction
@@ -111,7 +111,7 @@ function! ctrlspace#keys#help#ScrollDown(k)
 endfunction
 
 function! ctrlspace#keys#help#PageUp(k)
-	if s:config.UseMouseAndArrowsInTerm || has("gui_running")
+	if s:config.UseArrowsInTerm || s:config.UseMouseAndArrowsInTerm || has("gui_running")
 		call ctrlspace#window#MoveCursor("pgup")
 	endif
 endfunction

--- a/doc/ctrlspace.txt
+++ b/doc/ctrlspace.txt
@@ -62,20 +62,21 @@ Table of Contents                                            *ctrlspace-toc*
    7.6 g:CtrlSpaceHelp                                     |g:CtrlSpaceHelp|
    7.7 g:CtrlSpaceGlobCommand                       |g:CtrlSpaceGlobCommand|
    7.8 g:CtrlSpaceUseTabline                         |g:CtrlSpaceUseTabline|
-   7.9 g:CtrlSpaceUseMouseAndArrowsInTerm
+   7.9 g:CtrlSpaceUseArrowsInTerm               |g:CtrlSpaceUseArrowsInTerm|
+   7.10 g:CtrlSpaceUseMouseAndArrowsInTerm
                                         |g:CtrlSpaceUseMouseAndArrowsInTerm|
-   7.10 g:CtrlSpaceSaveWorkspaceOnExit      |g:CtrlSpaceSaveWorkspaceOnExit|
-   7.11 g:CtrlSpaceSaveWorkspaceOnSwitch  |g:CtrlSpaceSaveWorkspaceOnSwitch|
-   7.12 g:CtrlSpaceLoadLastWorkspaceOnStart
+   7.11 g:CtrlSpaceSaveWorkspaceOnExit      |g:CtrlSpaceSaveWorkspaceOnExit|
+   7.12 g:CtrlSpaceSaveWorkspaceOnSwitch  |g:CtrlSpaceSaveWorkspaceOnSwitch|
+   7.13 g:CtrlSpaceLoadLastWorkspaceOnStart
                                        |g:CtrlSpaceLoadLastWorkspaceOnStart|
-   7.13 g:CtrlSpaceCacheDir                            |g:CtrlSpaceCacheDir|
-   7.14 g:CtrlSpaceProjectRootMarkers        |g:CtrlSpaceProjectRootMarkers|
-   7.15 g:CtrlSpaceUseUnicode                        |g:CtrlSpaceUseUnicode|
-   7.16 g:CtrlSpaceSymbols                              |g:CtrlSpaceSymbols|
-   7.17 g:CtrlSpaceIgnoredFiles                    |g:CtrlSpaceIgnoredFiles|
-   7.18 g:CtrlSpaceStatuslineFunction        |g:CtrlSpaceStatuslineFunction|
-   7.19 g:CtrlSpaceSearchTiming                    |g:CtrlSpaceSearchTiming|
-   7.20 g:CtrlSpaceFileEngine                        |g:CtrlSpaceFileEngine|
+   7.14 g:CtrlSpaceCacheDir                            |g:CtrlSpaceCacheDir|
+   7.15 g:CtrlSpaceProjectRootMarkers        |g:CtrlSpaceProjectRootMarkers|
+   7.16 g:CtrlSpaceUseUnicode                        |g:CtrlSpaceUseUnicode|
+   7.17 g:CtrlSpaceSymbols                              |g:CtrlSpaceSymbols|
+   7.18 g:CtrlSpaceIgnoredFiles                    |g:CtrlSpaceIgnoredFiles|
+   7.19 g:CtrlSpaceStatuslineFunction        |g:CtrlSpaceStatuslineFunction|
+   7.20 g:CtrlSpaceSearchTiming                    |g:CtrlSpaceSearchTiming|
+   7.21 g:CtrlSpaceFileEngine                        |g:CtrlSpaceFileEngine|
  8. API                                                      |ctrlspace-api|
    8.1 Commands                                         |ctrlspace-commands|
      8.1.1 :CtrlSpace [keys]                                    |:CtrlSpace|
@@ -950,7 +951,19 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.9 *g:CtrlSpaceUseMouseAndArrowsInTerm*
+7.9 *g:CtrlSpaceUseArrowsInTerm*
+
+Should the plugin use arrows and <Home>, <End>, <PageUp>, <PageDown> keys
+in a terminal Vim.
+
+Default value: >
+
+    let g:CtrlSpaceUseArrowsInTerm = 0
+<
+                                                             |ctrlspace-toc|
+--------------------------------------------------------------------------
+
+7.10 *g:CtrlSpaceUseMouseAndArrowsInTerm*
 
 Should the plugin use mouse, arrows and <Home>, <End>, <PageUp>,
 <PageDown> keys in a terminal Vim. Disables the <Esc> key if turned on.
@@ -962,7 +975,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.10 *g:CtrlSpaceSaveWorkspaceOnExit*
+7.11 *g:CtrlSpaceSaveWorkspaceOnExit*
 
 Saves the active workspace (if present) on Vim quit. If this option is
 set, the Vim quit (<Q>) action in the plugin does not check for workspace
@@ -975,7 +988,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.11 *g:CtrlSpaceSaveWorkspaceOnSwitch*
+7.12 *g:CtrlSpaceSaveWorkspaceOnSwitch*
 
 Saves the active workspace (if present) on switching to another workspace
 or clearing (closing) the current one. If this option is set, the plugin
@@ -988,7 +1001,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.12 *g:CtrlSpaceLoadLastWorkspaceOnStart*
+7.13 *g:CtrlSpaceLoadLastWorkspaceOnStart*
 
 Loads the last active workspace (if found) on Vim startup.
 
@@ -999,7 +1012,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.13 *g:CtrlSpaceCacheDir*
+7.14 *g:CtrlSpaceCacheDir*
 
 A directory for the Vim-CtrlSpace cache file (`.cs_cache`). By default
 your `$HOME` directory will be used.
@@ -1011,7 +1024,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.14 *g:CtrlSpaceProjectRootMarkers*
+7.15 *g:CtrlSpaceProjectRootMarkers*
 
 An array of directory names which presence indicates the project root. If
 no marker is found, you will be asked to confirm the project root
@@ -1035,7 +1048,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.15 *g:CtrlSpaceUseUnicode*
+7.16 *g:CtrlSpaceUseUnicode*
 
 Set to `1` if you want to use Unicode symbols, or `0` otherwise.
 
@@ -1046,7 +1059,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.16 *g:CtrlSpaceSymbols*
+7.17 *g:CtrlSpaceSymbols*
 
 Enables you to provide your own symbols. It's useful if, for example, your
 font doesn't contain enough symbols or the glyphs are poorly rendered.
@@ -1086,7 +1099,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.17 *g:CtrlSpaceIgnoredFiles*
+7.18 *g:CtrlSpaceIgnoredFiles*
 
 The expression used to ignore some files during file collecting. It is
 used in addition to the `wildignore` option in Vim (see |wildignore|).
@@ -1101,7 +1114,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.18 *g:CtrlSpaceStatuslineFunction*
+7.19 *g:CtrlSpaceStatuslineFunction*
 
 Allows to provide custom statusline function used by the CtrlSpace window.
 
@@ -1112,7 +1125,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.19 *g:CtrlSpaceSearchTiming*
+7.20 *g:CtrlSpaceSearchTiming*
 
 Allows you to adjust search smoothness by providing a delay on search
 input. By default the delay is set to 200 ms. That way the plugin ensures
@@ -1125,7 +1138,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.20 *g:CtrlSpaceFileEngine*
+7.21 *g:CtrlSpaceFileEngine*
 
 The plugin provides fuzzy search engine written in Go and compiled for
 several architectures:


### PR DESCRIPTION
like UseMouseAndArrowsInTerm but without any mouse bindings and keeps <Esc> working

(brought over from [vim-ctrlspace/vim-ctrlspace/pull/179])